### PR TITLE
PoC using the playwright mcp to navigate to the page and generate playwright tests

### DIFF
--- a/.github/prompts/generate_test.prompt.md
+++ b/.github/prompts/generate_test.prompt.md
@@ -1,0 +1,7 @@
+- You are a playwright test generator.
+- You are given a scenario and you need to generate a playwright test for it.
+- DO NOT generate test code based on the scenario alone.
+- DO run steps one by one using the tools provided by the Playwright MCP.
+- Only after all steps are completed, emit a Playwright TypeScript test that uses @playwright/test based on message history
+- Save generated test file in the tests directory
+- Execute the test file and iterate until the test passes

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "jdoro-blog",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@playwright/test": "^1.52.0"
+      },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.8",
         "autoprefixer": "^10.4.21",
@@ -118,6 +121,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -1351,6 +1369,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "postcss": "^8.5.4",
     "postcss-cli": "^11.0.1",
     "tailwindcss": "^4.1.8"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.52.0"
   }
 }

--- a/tests/blog-post-navigation.spec.ts
+++ b/tests/blog-post-navigation.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+// Dynamically generate blog post slugs from content/posts directory
+function getPostSlugs() {
+  const postsDir = path.join(__dirname, '../content/posts');
+  const entries = fs.readdirSync(postsDir, { withFileTypes: true });
+  return entries
+    .map(entry => {
+      if (entry.isDirectory()) {
+        return entry.name;
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        return entry.name.replace(/\.md$/, '');
+      }
+      return null;
+    })
+    .filter(Boolean)
+    .map(slug => slug.toLowerCase())
+    .sort();
+}
+
+const postSlugs = getPostSlugs();
+const baseUrl = 'https://jdoro.github.io/jdoro-blog/posts/';
+
+test.describe('blog post navigation', () => {
+  postSlugs.forEach(slug => {
+    test(`can navigate to blog post: ${slug}`, async ({ page }) => {
+      await page.goto(`${baseUrl}${slug}/`);
+      const notFound = await page.locator('text=404').count();
+      expect(notFound).toBe(0);
+      const hasTitle = await page.locator('h2, h1').first().isVisible();
+      expect(hasTitle).toBeTruthy();
+    });
+  });
+});

--- a/tests/light-mode-toggle.spec.ts
+++ b/tests/light-mode-toggle.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('should activate light mode when the light button is clicked', async ({ page }) => {
+  // Step 1: Navigate to the blog
+  await page.goto('https://jdoro.github.io/jdoro-blog/');
+
+  // Step 2: Click the dark/light toggle button (initially dark)
+  await page.getByRole('button', { name: '🌙 Dark' }).click();
+
+  // Step 3: Verify that the light mode has been activated (button label changes to '☀️ Light')
+  await expect(page.getByRole('button', { name: '☀️ Light' })).toBeVisible();
+});
+


### PR DESCRIPTION
This pull request introduces Playwright testing capabilities to the project, enabling automated browser testing for blog navigation and UI interactions. It includes the addition of relevant dependencies, new test files, and a prompt for generating Playwright tests. Below is a summary of the most important changes:

### Playwright Test Integration:

* [`.github/prompts/generate_test.prompt.md`](diffhunk://#diff-696d3e873c9fc1b11f0abb86980f82032b6dcf1538edc9e45179794741e477eeR1-R7): Added a prompt for generating Playwright tests, outlining the process to create and validate TypeScript tests using the Playwright MCP tools.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R32-R34): Added `@playwright/test` as a dependency to support Playwright-based testing.

### New Test Files:

* [`tests/blog-post-navigation.spec.ts`](diffhunk://#diff-9cd5e027090c63f2431ac1ce9ffa87b618a7718d5ff1490ecf4e3166b7926dbfR1-R36): Added a test suite to verify navigation to blog posts. Dynamically generates blog post slugs from the `content/posts` directory and ensures that posts are accessible and display titles correctly.
* [`tests/light-mode-toggle.spec.ts`](diffhunk://#diff-6aa36377781fe7d34275257b563161e9487ce7104556b140078a85b6f91e4f83R1-R13): Added a test to verify the functionality of the light mode toggle button. Ensures that clicking the button switches the UI from dark mode to light mode.